### PR TITLE
fix: detect Flatpak apps when exports/bin is not in PATH

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,6 +2,17 @@ import GLib from 'gi://GLib';
 import Gio from 'gi://Gio';
 
 //------------------------------------------------------------------------------
+/// @brief Standard Flatpak export directories where executables may be located.
+///
+/// @note  These directories are not always included in PATH by default on all
+///        distributions (e.g., Ubuntu), so we check them explicitly.
+///
+const FLATPAK_BIN_PATHS = [
+    '/var/lib/flatpak/exports/bin',
+    GLib.build_filenamev([GLib.get_home_dir(), '.local', 'share', 'flatpak', 'exports', 'bin']),
+];
+
+//------------------------------------------------------------------------------
 /// @brief Class implementing a self-disconnecting signal connection.
 ///
 /// @note Useful for one-time connections in a static context e.g. use callback on next emission only.
@@ -135,28 +146,61 @@ export function execute(command) {
 }
 
 //--------------------------------------------------------------------------
-/// @brief Determines if given *name* command is available
+/// @brief Finds executable path for given command name.
 ///
 /// @param      {String}   name  Command name.
 ///
-/// @return     {Boolean}  True if given 'name' command is in PATH, False otherwise.
+/// @return     {String|null}  Full path to executable if found, null otherwise.
+///
+/// @note       Checks both system PATH and standard Flatpak export directories,
+///             since Flatpak directories are not always in PATH by default
+///             (e.g., on Ubuntu and some other distributions).
+///
+export function find_executable(name) {
+    // First check system PATH
+    let path = GLib.find_program_in_path(name);
+    if (path) {
+        return path;
+    }
+
+    // Then check standard Flatpak export directories
+    for (const dir of FLATPAK_BIN_PATHS) {
+        const fullPath = GLib.build_filenamev([dir, name]);
+        if (GLib.file_test(fullPath, GLib.FileTest.IS_EXECUTABLE)) {
+            return fullPath;
+        }
+    }
+
+    return null;
+}
+
+//--------------------------------------------------------------------------
+/// @brief Determines if given *name* command is available
+///
+/// @param      {String}   name  Command name or full path.
+///
+/// @return     {Boolean}  True if command is available, False otherwise.
+///
+/// @note       Checks both system PATH and standard Flatpak export directories.
 ///
 export function is_available(name) {
-    return Boolean(GLib.find_program_in_path(name));
+    return Boolean(find_executable(name));
 }
 
 //------------------------------------------------------------------------------
 /// @brief Finds first available command/executable from given possibilities
 ///
-/// @param      Commands/executable  [from=[]]  The from
-/// @return     {string}  { description_of_the_return_value }
+/// @param      {Array}   commands  Array of command names to check.
 ///
-/// @note       Wraps around is_available to find executables available on system's path.
+/// @return     {String|null}  Full path to first available executable, or null if none found.
+///
+/// @note       Checks both system PATH and standard Flatpak export directories.
 ///
 export function first_available(commands = []) {
     for (var i = commands.length - 1; i >= 0; i--) {
-        if (is_available(commands[i])) {
-            return commands[i];
+        const path = find_executable(commands[i]);
+        if (path) {
+            return path;
         }
     }
 


### PR DESCRIPTION
## Summary
On Ubuntu and some other distributions, the Flatpak export directory (`/var/lib/flatpak/exports/bin`) is not included in `PATH` by default. This causes the extension to fail with:

```
Error: Argument program may not be null
```

when Sticky Notes is installed via Flatpak.

## Changes
- Added `FLATPAK_BIN_PATHS` constant with standard Flatpak export directories
- Added `find_executable()` function that checks both PATH and Flatpak directories
- Updated `is_available()` and `first_available()` to use the new function

## Test plan
- [x] Tested on Ubuntu with Sticky Notes installed via `flatpak install flathub com.vixalien.sticky`
- [x] Verified extension preferences now open without error
- [x] Confirmed backward compatibility (still works when app is in PATH)

Fixes #6